### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# This document allows GitHub to identify Markdown as a language and add them to GitHub Repository's language statistics.
+# https://gist.github.com/TitanRGB/5c7d35afb0999bfc7a3e03adab99438b
+*.md linguist-detectable=true
+*.md linguist-documentation=false


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/75297777/183904899-18af07bb-d9de-4c1c-aef2-2c9dbc280988.png)

While this repo is pure docs, why not let the language counter enable and shows Markdown